### PR TITLE
Fixing panic when filter has extra opening parentheses.

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -60,8 +60,11 @@ func CompileFilter(filter string) (*ber.Packet, error) {
 	if err != nil {
 		return nil, err
 	}
-	if pos != len(filter) {
+	if pos < len(filter) {
 		return nil, NewError(ErrorFilterCompile, errors.New("ldap: finished compiling filter with extra at end: "+fmt.Sprint(filter[pos:])))
+	}
+	if pos != len(filter) {
+		return nil, NewError(ErrorFilterCompile, errors.New("ldap: filter has too many opening parentheses"))
 	}
 	return packet, nil
 }


### PR DESCRIPTION
Top of the stack trace:

panic: runtime error: slice bounds out of range

goroutine 16918 [running]:
ldap.CompileFilter(0xc421e450a0, 0x17, 0xa, 0xc423c847e0, 0xa)
ldap/filter.go:64 +0x361
ldap.(*SearchRequest).encode(0xc4238f13e8, 0xc423c844e0, 0xc423ca7040, 0x449abaf)
ldap/search.go:203 +0x316